### PR TITLE
Revert "Bump boto3 from 1.13.11 to 1.14.8"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.14.8
+boto3==1.13.11
 python-lambda==11.7.1
 requests==2.24.0


### PR DESCRIPTION
Reverts GovWizely/lambda-ustda-trade-events#59

The update is incompatible with pyhton-lambda